### PR TITLE
Add mouse click event to save button

### DIFF
--- a/src/TableEditColumn.js
+++ b/src/TableEditColumn.js
@@ -25,6 +25,9 @@ class TableEditColumn extends Component {
     } else if (e.keyCode === 27) {
       this.props.completeEdit(
         null, this.props.rowIndex, this.props.colIndex);
+    } else if ('click' === e.type) {
+      var value = _this.refs.inputRef.value;
+      _this.props.completeEdit(value, _this.props.rowIndex, _this.props.colIndex);
     }
   }
 


### PR DESCRIPTION
I use {blurToSave: false} and { type: 'textarea' } to create multiple line textaera, when I click the save button, it won't save changes at all. 

So I create this pull request to fix this.
